### PR TITLE
CHANGE: changed default model in model choice

### DIFF
--- a/demos/model_choice/chat_with_model_choice.py
+++ b/demos/model_choice/chat_with_model_choice.py
@@ -175,7 +175,7 @@ custom_css = """
 with (gr.Blocks(fill_height=True, title='OpenRouter Model Choice', css=custom_css) as llm_client_ui):
     # state
     messages = gr.State([system_instruction])
-    selected_model = gr.State('google/gemini-2.0-flash-001')
+    selected_model = gr.State('deepseek/deepseek-chat-v3.1')
     df_models = gr.State(None)
 
     # ui

--- a/demos/model_choice/or_pricing.py
+++ b/demos/model_choice/or_pricing.py
@@ -3,6 +3,7 @@ import os
 
 import pandas as pd
 import requests
+import pprint as pp
 
 from demos.image_analysis.utils import load_model_scores, sort_models_by_score
 
@@ -89,6 +90,7 @@ def get_models(tools_only=True, names_only=True, as_dataframe=False):
 
 def no_duplicates(list_with_duplicates):
     return list(dict.fromkeys(list_with_duplicates))
+
 
 # uncomment to see pricing in terminal
 # with pd.option_context('display.max_rows', None, 'display.max_columns', None):


### PR DESCRIPTION
This pull request makes minor updates to the model selection default and adds a new import for pretty-printing in the pricing script. The most notable change is updating the default selected model in the UI.

Model selection update:
* Changed the default model in the `chat_with_model_choice.py` UI from `'google/gemini-2.0-flash-001'` to `'deepseek/deepseek-chat-v3.1'`, so new sessions will use the DeepSeek model by default.

Code maintenance:
* Added `import pprint as pp` to `or_pricing.py` to support pretty-printing, which can help with debugging and inspecting data in the terminal.
* Minor formatting: inserted a blank line after a utility function for readability in `or_pricing.py`.